### PR TITLE
Fix recipe serializer in multiplayer

### DIFF
--- a/src/main/java/com/ncpbails/modestmining/recipe/ForgeRecipe.java
+++ b/src/main/java/com/ncpbails/modestmining/recipe/ForgeRecipe.java
@@ -155,7 +155,6 @@ public class ForgeRecipe implements Recipe<SimpleContainer> {
         }
         @Override
         public ForgeRecipe fromNetwork(ResourceLocation id, FriendlyByteBuf buf) {
-            String s = buf.readUtf();
             int i = buf.readVarInt();
             NonNullList<Ingredient> inputs = NonNullList.withSize(i, Ingredient.EMPTY);
 
@@ -178,6 +177,8 @@ public class ForgeRecipe implements Recipe<SimpleContainer> {
             }
 
             buf.writeItem(recipe.getResultItem());
+            buf.writeVarInt(recipe.cookTime);
+
         }
     }
 }

--- a/src/main/java/com/ncpbails/modestmining/recipe/ForgeShapedRecipe.java
+++ b/src/main/java/com/ncpbails/modestmining/recipe/ForgeShapedRecipe.java
@@ -361,7 +361,6 @@ public class ForgeShapedRecipe implements Recipe<SimpleContainer> {
         public ForgeShapedRecipe fromNetwork(ResourceLocation id, FriendlyByteBuf buf) {
             int width = buf.readVarInt();
             int height = buf.readVarInt();
-            String s = buf.readUtf();
             NonNullList<Ingredient> nonnulllist = NonNullList.withSize(width * height, Ingredient.EMPTY);
 
             for(int k = 0; k < nonnulllist.size(); ++k) {
@@ -383,6 +382,7 @@ public class ForgeShapedRecipe implements Recipe<SimpleContainer> {
             }
 
             buf.writeItem(recipe.getResultItem());
+            buf.writeVarInt(recipe.cookTime);
         }
     }
 }


### PR DESCRIPTION
The recipe serializer was writing cooktime into the packet, but wasn't reading it, leading it to not know how to decode the recipe because everything was misaligned. This didn't happen in singleplayer because singleplayer doesn't read recipes over the network.