### PR TITLE
Fix fuel in recipes not being synced

### DIFF
--- a/src/main/java/com/ncpbails/modestmining/recipe/ForgeRecipe.java
+++ b/src/main/java/com/ncpbails/modestmining/recipe/ForgeRecipe.java
@@ -164,7 +164,7 @@ public class ForgeRecipe implements Recipe<SimpleContainer> {
 
             ItemStack itemstack = buf.readItem();
             int cookTimeIn = buf.readVarInt();
-            Ingredient fuel = Ingredient.EMPTY;
+            Ingredient fuel = Ingredient.fromNetwork(buf);
             return new ForgeRecipe(id, itemstack, inputs, fuel, cookTimeIn);
         }
 
@@ -178,6 +178,7 @@ public class ForgeRecipe implements Recipe<SimpleContainer> {
 
             buf.writeItem(recipe.getResultItem());
             buf.writeVarInt(recipe.cookTime);
+            recipe.fuel.toNetwork(buf);
 
         }
     }

--- a/src/main/java/com/ncpbails/modestmining/recipe/ForgeShapedRecipe.java
+++ b/src/main/java/com/ncpbails/modestmining/recipe/ForgeShapedRecipe.java
@@ -369,7 +369,7 @@ public class ForgeShapedRecipe implements Recipe<SimpleContainer> {
 
             ItemStack itemstack = buf.readItem();
             int cookTimeIn = buf.readVarInt();
-            Ingredient fuel = Ingredient.EMPTY;
+            Ingredient fuel = Ingredient.fromNetwork(buf);
             return new ForgeShapedRecipe(width, height, id, itemstack, nonnulllist, fuel, cookTimeIn);
         }
 
@@ -383,6 +383,7 @@ public class ForgeShapedRecipe implements Recipe<SimpleContainer> {
 
             buf.writeItem(recipe.getResultItem());
             buf.writeVarInt(recipe.cookTime);
+            recipe.fuel.toNetwork(buf);
         }
     }
 }


### PR DESCRIPTION
Fuel was absent from the networking, leading to only air being a valid fuel.