### PR TITLE
Fix millstone recipe

### DIFF
--- a/src/main/java/com/baisylia/modestmining/block/entity/ModBlockEntities.java
+++ b/src/main/java/com/baisylia/modestmining/block/entity/ModBlockEntities.java
@@ -26,13 +26,11 @@ public class ModBlockEntities {
             BLOCK_ENTITIES.register("forge_block_entity", () ->
                     BlockEntityType.Builder.of(ForgeBlockEntity::new,
                             ModBlocks.FORGE.get()).build(null));
+
     public static final RegistryObject<BlockEntityType<MillstoneBlockEntity>> MILLSTONE_BLOCK_ENTITY =
             BLOCK_ENTITIES.register("millstone_block_entity", () ->
                     BlockEntityType.Builder.of(MillstoneBlockEntity::new,
-                            ModBlocks.FORGE.get()).build(null));
-
-
-
+                            ModBlocks.MILLSTONE.get()).build(null));
 
     public static void register(IEventBus eventBus) {
         BLOCK_ENTITIES.register(eventBus);

--- a/src/main/java/com/baisylia/modestmining/integration/emi/EMIModestMiningPlugin.java
+++ b/src/main/java/com/baisylia/modestmining/integration/emi/EMIModestMiningPlugin.java
@@ -1,9 +1,10 @@
 package com.baisylia.modestmining.integration.emi;
 
-import com.baisylia.modestmining.recipe.AbstractForgeRecipe;
-import com.baisylia.modestmining.recipe.ModRecipes;
 import com.baisylia.modestmining.ModestMining;
 import com.baisylia.modestmining.block.ModBlocks;
+import com.baisylia.modestmining.recipe.AbstractForgeRecipe;
+import com.baisylia.modestmining.recipe.AbstractMillstoneRecipe;
+import com.baisylia.modestmining.recipe.ModRecipes;
 import com.baisylia.modestmining.screen.ModMenuTypes;
 import dev.emi.emi.api.EmiEntrypoint;
 import dev.emi.emi.api.EmiPlugin;
@@ -16,7 +17,7 @@ import net.minecraft.resources.ResourceLocation;
 public class EMIModestMiningPlugin implements EmiPlugin {
 
     public static final EmiRecipeCategory FORGING =
-        new EmiRecipeCategory(new ResourceLocation(ModestMining.MOD_ID, "forging"), EmiStack.of(ModBlocks.FORGE.get()));
+            new EmiRecipeCategory(new ResourceLocation(ModestMining.MOD_ID, "forging"), EmiStack.of(ModBlocks.FORGE.get()));
 
     public static final EmiRecipeCategory MILLING =
             new EmiRecipeCategory(new ResourceLocation(ModestMining.MOD_ID, "milling"), EmiStack.of(ModBlocks.MILLSTONE.get()));
@@ -29,6 +30,12 @@ public class EMIModestMiningPlugin implements EmiPlugin {
             registry.addRecipe(new ForgingEmiRecipe(recipe));
         }
         registry.addRecipeHandler(ModMenuTypes.FORGE_MENU.get(), new ForgingEmiRecipeHandler());
-    }
 
+        registry.addCategory(MILLING);
+        registry.addWorkstation(MILLING, EmiStack.of(ModBlocks.MILLSTONE.get()));
+        for (AbstractMillstoneRecipe recipe : registry.getRecipeManager().getAllRecipesFor(ModRecipes.MILLING_TYPE.get())) {
+            registry.addRecipe(new MillingEmiRecipe(recipe));
+        }
+        registry.addRecipeHandler(ModMenuTypes.MILLSTONE_MENU.get(), new MillingEmiRecipeHandler());
+    }
 }

--- a/src/main/resources/data/modestmining/recipes/milling/test.json
+++ b/src/main/resources/data/modestmining/recipes/milling/test.json
@@ -16,9 +16,6 @@
       "item": "minecraft:gold_ingot"
     }
   ],
-  "fuel": {
-    "item": "minecraft:blaze_powder"
-  },
   "result": {
     "item": "minecraft:blaze_powder"
   }


### PR DESCRIPTION
- Fixes the millstone block entity registration to point to the millstone block instead of the forge
- Registers the millstone recipe type in EMI
- Removes the undefined fuel array from the test recipe